### PR TITLE
Links fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We're going to search for more tasks from national selections and fix the links,
 
 [Problem statements in zip archive](https://ioai-official.org/wp-content/uploads/2025/06/At-home-problems.zip)
 
-[Solutions in zip archive](https://ioai-official.org/wp-content/uploads/2025/06/At-home-solutions.zip)
+[Solutions in zip archive](https://ioai-official.org/wp-content/uploads/2025/06/Best-solutions-at-home-problems.zip)
 
 ### Scientific Round – On-Site Stage (Aug 2024)
 - ML – Generate best features for a fixed ML model on structured data, where each samples is a matrix. Compared to at-home task, the data, the model, and the problem (classification vs regression) changed.
@@ -20,10 +20,10 @@ We're going to search for more tasks from national selections and fix the links,
 
 [Problem statements](https://ioai-official.org/wp-content/uploads/2025/06/On-site-problems.zip)
 
-[Solutions](https://ioai-official.org/wp-content/uploads/2025/06/On-site-solutions.zip)
+[Solutions](https://ioai-official.org/wp-content/uploads/2025/06/Best-solutions-onsite.zip)
 
 ### Practical Round – On-Site (Aug 2024)
-- [Generative AI (Image and Video)](https://ioai-official.org/wp-content/uploads/2025/06/Practical-round-assignment.zip) – create an album cover and produce a short video segment for the song remix. [Best solution](https://ioai-official.org/wp-content/uploads/2025/06/Practical-best-solution.zip)
+- [Generative AI (Image and Video)](https://ioai-official.org/wp-content/uploads/2025/06/Practical-Round-problems.zip) – create an album cover and produce a short video segment for the song remix. [Best solution](https://ioai-official.org/wp-content/uploads/2025/06/Practical-round-best-solutions.zip)
 
 ## APOAI (Asia-Pacific Olympiad in AI)
 
@@ -35,12 +35,12 @@ We're going to search for more tasks from national selections and fix the links,
 
 - [Evading AI-Generated Text Detection](https://github.com/open-cu/neoai-2025/tree/main/3_Evading_AI_Generated_Text_Detection) - NLP - craft AI text that bypasses detectors
 - [Broken BERT](https://github.com/open-cu/neoai-2025/tree/main/5_Broken_BERT) - NLP - repair a corrupted BERT model’s embeddings
-- [Cluster Pictures](https://github.com/open-cu/neoai-2025/tree/main/2_Cluster_Pictures) - CV - unsupervised clustering of image patches
+- [Cluster Pictures](https://www.kaggle.com/competitions/neoai-2025-cluster-pictures) - CV - unsupervised clustering of image patches
 - [Cuties Segmentation](https://github.com/open-cu/neoai-2025/tree/main/8_Cuties_Segmentation) - CV - semantic segmentation of cartoon characters
 - [Hogspell Challenge](https://github.com/lenjjiv/steering-hogs) - Generative (Image) - steer a diffusion model to generate hog images
-- [Tricy Table](https://www.kaggle.com/competitions/neoai-2025) - ML - tabular feature engineering challenge
-- [Underfitting CV](https://www.kaggle.com/competitions/neoai-2025) - CV - improve underfitting vision models
-- [Intent Detection & Slot Filling](https://www.kaggle.com/competitions/neoai-2025) - NLP - multilingual intent classification and slot filling
+- [Tricy Table](https://www.kaggle.com/competitions/neoai-2025-tricy-table-data) - ML - tabular feature engineering challenge
+- [Underfitting CV](https://www.kaggle.com/competitions/neoai-2025-underfitting-cv) - CV - improve underfitting vision models
+- [Intent Detection & Slot Filling](https://www.kaggle.com/competitions/neoai-2025-intent-detection-and-slot-filling) - NLP - multilingual intent classification and slot filling
 
 *Overview:* [NEOAI 2025 on Kaggle](https://www.kaggle.com/competitions/neoai-2025/overview)
 
@@ -58,10 +58,10 @@ We're going to search for more tasks from national selections and fix the links,
 
 ## China – NOAI 2025
 ### Phase 1 – National Qualifier (Mar 30, 2025)
-- [Details & syllabus](https://ioai-official.org/china-2025/syllabus-2025/) – Programming & AI theory – 2‑hour digital exam on Python, data structures, and AI concepts.
+- [Official IOAI Syllabus](https://ioai-official.org/china-2025/syllabus-2025/) – The national qualifier is a digital exam on Python, data structures, and AI concepts, for which this general IOAI syllabus is relevant.
 
 ### Phase 2 – National Finals (Jun 2, 2025)
-- On‑site contest with four high‑difficulty AI problems across ML, CV, NLP, and ethics.
+- On‑site contest with four high‑difficulty AI problems across ML, CV, NLP, and ethics. [Results & Overview](https://ioai-official.org/noai-china-finals-2025-8-team-members-selected-for-chinas-national-team-for-ioai-2025/)
 
 ## Georgia - Selection 2025
 - [Classic ML task](https://www.bohrium.com/competitions/3072370612?tab=introduce) - problem where students should align 3 binary classification models to do predictions on 3 class classification
@@ -69,6 +69,7 @@ We're going to search for more tasks from national selections and fix the links,
 - [CV task](https://www.bohrium.com/competitions/6576265377?tab=introduce) - Students have a list of classes, images without labels, and captions generated from an image2text model on these images, and their task is to train a classifier on these images for the given list of classes
 
 ## India – INAIO Selection 2025
+- [Official Website](https://www.acmindia.org/education/india-ai-olympiad)
 - **Stage 1 (Jan 25, 2025):** Online test on AI fundamentals; tools like ChatGPT/Google permitted.
 - **Stage 2 (Mar 2, 2025):** Proctored exam with AI theory questions and Python ML coding tasks.
 
@@ -80,14 +81,14 @@ We're going to search for more tasks from national selections and fix the links,
 - [Day 2: Player Clustering](https://github.com/batyrq/IOAI-TST-solution-day2) – ML – cluster football players by statistics.
 - [Day 3: Code Difficulty Classification](https://github.com/batyrq/IOAI-TST-solution-day3) – NLP – label code snippets as easy, medium, or hard.
 - [Day 4: Masked Word Position](https://github.com/batyrq/IOAI-TST-solution-day4) – NLP – recover the position of a masked word in a sentence.
-- [All solutions](https://github.com/batyrq) – Consolidated repository for Kazakhstan's IOAI team selection tasks.
+- [All solutions](https://github.com/batyrq?tab=repositories) – Consolidated repository for Kazakhstan's IOAI team selection tasks.
 
 ## Malaysia – IOAI Training and Selection Programme 2025
 - [Lab repository](https://github.com/jaredliw/ioai-tsp-2025) – ML/CV/Multimodal – ResNet fine-tuning, FCN segmentation, and multimodality labs for Malaysia's team.
 
 ## Poland – Polish AI Olympiad
 ### 1st Edition – 2024
-- **Stage I (Online Apr 22–May 27):** [Tasks](https://github.com/OlimpiadaAI/I-OlimpiadaAI) – CV/ML/NLP – adversarial attacks, imbalanced classification, parsing, quantization, tracking, pruning, reading-comprehension riddles.
+- **Stage I (Online Apr 22–May 27):** [Tasks](https://github.com/OlimpiadaAI/I-OlimpiadaAI/tree/main/first_stage) – CV/ML/NLP – adversarial attacks, imbalanced classification, parsing, quantization, tracking, pruning, reading-comprehension riddles.
 - **Final Stage (Bootcamp Jun 15–21):** [Tasks](https://github.com/OlimpiadaAI/I-OlimpiadaAI/tree/main/final_stage) – ML/CV/NLP – cipher breaking, OOD image detection, self-supervised time-series classification, machine translation contest.
 
 ### 2nd Edition – 2025
@@ -108,13 +109,10 @@ We're going to search for more tasks from national selections and fix the links,
 - [Solution write-ups](https://github.com/stefanasandei/roai-solved/blob/main/00-guide/rezolvari.md) – Detailed analyses of ROAI problems.
 
 ## Serbia – National Selection for IOAI 2025
-- National finals – scientific questions followed by team practical projects; top 4 advance.
-
-## Singapore – NOAI Singapore 2025
-- NLP – detect implicit toxicity in social media comments (binary classification). Baseline notebook provided in NOAI Singapore materials.
+- [Selection Overview](https://ioai-official.org/serbia-finals-4-team-members-selected-for-serbian-national-team-for-ioai-2025/) – National finals – scientific questions followed by team practical projects; top 4 advance.
 
 ## Tunisia – National AI Olympiad 2025
-- Mixed AI challenges – individual and team hackathon-style tasks at the National AI Conference & Hackathon; selects IOAI representatives.
+- [Selection Overview](https://ioai-official.org/ai-tunisia-national-round-the-way-to-the-excellence-through-the-ioai-world-portal/) – Mixed AI challenges – individual and team hackathon-style tasks at the National AI Conference & Hackathon; selects IOAI representatives.
 
 ## United States – USA‑North America AI Olympiad 2025
 - **Round 1 (Mar 24, 2025, Online):** ML & data analysis – spectral decomposition, neural-network fundamentals, Titanic dataset tasks. [Overview](https://ioai-official.org/the-usa-north-america-ai-olympiad-is-organized-by-the-usa-ai-olympiad-usaaio/)


### PR DESCRIPTION
Changed links for ioai 2024 tasks and soultions, neoai 2025 contests, Tunisia, Serbia, and Poland national selections. Deleted information about Singapore selection.